### PR TITLE
Remove unused maven-surefire-plugin config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -373,21 +373,6 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>${maven-surefire-plugin.version}</version>
-        <configuration>
-          <excludes>
-            <exclude>org/folio/rs/Controller/**Test.class</exclude>
-          </excludes>
-          <includes>
-            <include>org/folio/rs/TestSuite.class</include>
-          </includes>
-          <useSystemClassLoader>false</useSystemClassLoader>
-        </configuration>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
         <version>${maven-release-plugin.version}</version>
         <configuration>


### PR DESCRIPTION
The config suppresses all tests.
Remove config to enable all tests.