### PR TITLE
MODCITEM-8: Upgrade Spring Boot, Kafka, Hazelcast fixing vulns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.1.4</version>
+    <version>3.1.5</version>
     <relativePath />
   </parent>
 
@@ -24,6 +24,8 @@
 
   <properties>
     <java.version>17</java.version>
+    <spring-kafka.version>3.1.0</spring-kafka.version>
+    <kafka.version>3.6.0</kafka.version>
     <folio-spring-base.version>7.2.0</folio-spring-base.version>
     <openapi-generator.version>6.2.1</openapi-generator.version>
     <mapstruct.version>1.5.3.Final</mapstruct.version>


### PR DESCRIPTION
https://issues.folio.org/browse/MODCITEM-8

Upgrade Spring Boot from 3.1.4 to 3.1.5.

The Spring Boot upgrade indirectly upgrades tomcat-embed-core from 10.1.13 to 10.1.15 fixing Denial of Service (DoS) and Improper Input Validation and Incomplete Cleanup: https://nvd.nist.gov/vuln/detail/CVE-2023-44487 , https://nvd.nist.gov/vuln/detail/CVE-2023-45648 , https://nvd.nist.gov/vuln/detail/CVE-2023-42795

Upgrade spring-kafka from 3.0.11 to 3.1.0 and - correspondingly - kafka from 3.4.1 to 3.6.0.

The kafka upgrade indirectly upgrades snappy-java from 1.1.8.4 to 1.1.10.4 fixing four denial of service (DoS) and out of memory (OOM) issues: https://security.snyk.io/package/maven/org.xerial.snappy:snappy-java

Upgrade hazelcast from 5.2.1 to 5.3.6 fixing Incorrect Permission Assignment for Critical Resource and Insufficiently Protected Credentials: https://nvd.nist.gov/vuln/detail/CVE-2023-33265 , https://nvd.nist.gov/vuln/detail/CVE-2023-33264