### PR TITLE
MODCITEM-22 Use query based endpoint for fetchByBarcode

### DIFF
--- a/src/main/java/org/folio/circulation/item/controller/CirculationItemController.java
+++ b/src/main/java/org/folio/circulation/item/controller/CirculationItemController.java
@@ -43,16 +43,6 @@ public class CirculationItemController implements CirculationItemApi {
   }
 
   @Override
-  public ResponseEntity<CirculationItem> getCirculationItemByBarcode(String barcode) {
-    log.info("getCirculationItemByBarcode:: get circulationItem by barcode = {}", barcode);
-    var circulationItem = circulationItemServiceImpl.getCirculationItemByBarcode(barcode);
-    return isNull(circulationItem) ?
-      ResponseEntity.notFound().build() :
-      ResponseEntity.status(HttpStatus.OK)
-        .body(circulationItem);
-  }
-
-  @Override
   public ResponseEntity<CirculationItem> updateCirculationItem(String circulationItemId, CirculationItem circulationItem) {
     log.info("updateCirculationItem:: updating circulationItem by Request id= {} with entity id= {}", circulationItemId, circulationItem.getId());
     return ResponseEntity.status(HttpStatus.OK)

--- a/src/main/resources/swagger.api/circulation-item.yaml
+++ b/src/main/resources/swagger.api/circulation-item.yaml
@@ -5,35 +5,6 @@ info:
 paths:
   /circulation-item:
     get:
-      description: Get circulation item by barcode
-      operationId: getCirculationItemByBarcode
-      responses:
-        '200':
-          description: Circulation Item retrieved successfully
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/circulationItem"
-        '404':
-          description: Circulation Item not found
-          content:
-            application/json:
-              schema:
-                $ref: "schemas/common.yaml#/Error"
-        '500':
-          description: Internal server error
-          content:
-            application/json:
-              schema:
-                $ref: "schemas/common.yaml#/Error"
-    parameters:
-      - name: barcode
-        in: query
-        required: true
-        schema:
-          type: string
-  /circulation-item/items:
-    get:
       description: Return a list of items based on query
       operationId: getCirculationItemsByQuery
       parameters:

--- a/src/test/java/org/folio/circulation/item/controller/CirculationItemControllerTest.java
+++ b/src/test/java/org/folio/circulation/item/controller/CirculationItemControllerTest.java
@@ -119,7 +119,7 @@ class CirculationItemControllerTest extends BaseIT {
       .andExpect(jsonPath("$.barcode").value("0000"));
 
     mockMvc.perform(
-        get(URI_TEMPLATE_CIRCULATION_ITEM + "/items?query=id=="+id)
+        get("/circulation-item?query=id=="+id)
           .headers(defaultHeaders())
           .contentType(MediaType.APPLICATION_JSON))
       .andExpect(status().isOk());


### PR DESCRIPTION
Covers: [MODCITEM-22](https://issues.folio.org/browse/MODCITEM-22)

## Purpose
_Describe the purpose of the pull request. Include background information if necessary._

Currently, to fetch circulation-item by barcode mod-circulation uses parameter based endpoint which returns single item. But currently mod-circulation assumes that parameter based endpoints should return map of items. It creates challenges to cover with Unit tests. As in scope of [CIRC-1966](https://issues.folio.org/browse/CIRC-1966)
in mod-circulation-storage implemented Cql query based endpoint replace parameter based request with Cql based query.

