### PR TITLE
MODCITEM-25 Upgrading dependencies for Quesnelia release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,14 +24,13 @@
 
   <properties>
     <java.version>17</java.version>
-    <folio-spring-base.version>8.1.0</folio-spring-base.version>
+    <folio-spring.version>8.1.0</folio-spring.version>
     <openapi-generator.version>7.3.0</openapi-generator.version>
     <mapstruct.version>1.5.3.Final</mapstruct.version>
-    <wiremock.version>3.2.0</wiremock.version>
+    <wiremock.version>3.4.2</wiremock.version>
     <testcontainers.version>1.19.3</testcontainers.version>
     <embedded.db.version>2.2.0</embedded.db.version>
     <folio-util.version>35.0.3</folio-util.version>
-    <folio-spring-cql.version>8.1.0</folio-spring-cql.version>
     <commons-lang3.version>3.14.0</commons-lang3.version>
     <validation-api.version>2.0.1.Final</validation-api.version>
 
@@ -45,7 +44,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-spring-base</artifactId>
-      <version>${folio-spring-base.version}</version>
+      <version>${folio-spring.version}</version>
     </dependency>
 
     <dependency>
@@ -66,7 +65,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-spring-cql</artifactId>
-      <version>${folio-spring-cql.version}</version>
+      <version>${folio-spring.version}</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -37,8 +37,6 @@
     <copy-rename-maven-plugin.version>1.0</copy-rename-maven-plugin.version>
     <jsonschema2pojo-maven-plugin.version>1.1.2</jsonschema2pojo-maven-plugin.version>
     <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
-    <sonar.exclusions>src/main/java/org/folio/rs/domain/**, src/main/java/org/folio/rs/client/AuthnClient.java,
-      src/main/java/org/folio/rs/config/properties/**, src/main/java/org/folio/rs/service/PubSubService.java, src/main/java/org/folio/rs/error/PubSubException.java </sonar.exclusions>
     <circulation-item.yaml.file>src/main/resources/swagger.api/circulation-item.yaml</circulation-item.yaml.file>
   </properties>
 
@@ -47,10 +45,6 @@
       <groupId>org.folio</groupId>
       <artifactId>folio-spring-base</artifactId>
       <version>${folio-spring-base.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.kafka</groupId>
-      <artifactId>spring-kafka</artifactId>
     </dependency>
 
     <dependency>
@@ -192,14 +186,6 @@
       <artifactId>wiremock-standalone</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
-    </dependency>
-
-
-    <dependency>
-      <groupId>org.folio</groupId>
-      <artifactId>mod-pubsub-client</artifactId>
-      <version>${pubsub.client.version}</version>
-      <type>jar</type>
     </dependency>
 
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -24,20 +24,20 @@
 
   <properties>
     <java.version>17</java.version>
-    <folio-spring-base.version>8.0.0</folio-spring-base.version>
-    <openapi-generator.version>6.2.1</openapi-generator.version>
+    <folio-spring-base.version>8.1.0</folio-spring-base.version>
+    <openapi-generator.version>7.3.0</openapi-generator.version>
     <mapstruct.version>1.5.3.Final</mapstruct.version>
-    <wiremock.version>2.27.2</wiremock.version>
-    <testcontainers.version>1.17.6</testcontainers.version>
+    <wiremock.version>3.2.0</wiremock.version>
+    <testcontainers.version>1.19.3</testcontainers.version>
     <embedded.db.version>2.2.0</embedded.db.version>
     <folio-util.version>35.0.3</folio-util.version>
-    <folio-spring-cql.version>8.0.0</folio-spring-cql.version>
+    <folio-spring-cql.version>8.1.0</folio-spring-cql.version>
     <commons-lang3.version>3.14.0</commons-lang3.version>
     <validation-api.version>2.0.1.Final</validation-api.version>
 
-    <copy-rename-maven-plugin.version>1.0</copy-rename-maven-plugin.version>
+    <copy-rename-maven-plugin.version>1.0.1</copy-rename-maven-plugin.version>
     <jsonschema2pojo-maven-plugin.version>1.1.2</jsonschema2pojo-maven-plugin.version>
-    <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
+    <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
     <circulation-item.yaml.file>src/main/resources/swagger.api/circulation-item.yaml</circulation-item.yaml.file>
   </properties>
 
@@ -195,7 +195,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
+      <groupId>org.wiremock</groupId>
       <artifactId>wiremock-standalone</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
@@ -309,8 +309,8 @@
               <generateSupportingFiles>true</generateSupportingFiles>
               <supportingFilesToGenerate>ApiUtil.java</supportingFilesToGenerate>
               <generateModelDocumentation>true</generateModelDocumentation>
-              <inlineSchemaNameDefaults>arrayItemSuffix=</inlineSchemaNameDefaults>
               <configOptions>
+                <generatedConstructorWithRequiredArgs>false</generatedConstructorWithRequiredArgs>
                 <dateLibrary>java</dateLibrary>
                 <interfaceOnly>true</interfaceOnly>
                 <useSpringBoot3>true</useSpringBoot3>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.3</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
   <properties>
     <java.version>17</java.version>
-    <folio-spring-base.version>7.2.2</folio-spring-base.version>
+    <folio-spring-base.version>8.0.0</folio-spring-base.version>
     <openapi-generator.version>6.2.1</openapi-generator.version>
     <mapstruct.version>1.5.3.Final</mapstruct.version>
     <wiremock.version>2.27.2</wiremock.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.1.5</version>
+    <version>3.2.0</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
   <properties>
     <java.version>17</java.version>
-    <folio-spring-base.version>8.0.0</folio-spring-base.version>
+    <folio-spring-base.version>7.2.2</folio-spring-base.version>
     <openapi-generator.version>6.2.1</openapi-generator.version>
     <mapstruct.version>1.5.3.Final</mapstruct.version>
     <wiremock.version>2.27.2</wiremock.version>
@@ -32,6 +32,8 @@
     <embedded.db.version>2.2.0</embedded.db.version>
     <folio-util.version>35.0.3</folio-util.version>
     <folio-spring-cql.version>8.0.0</folio-spring-cql.version>
+    <commons-lang3.version>3.14.0</commons-lang3.version>
+    <validation-api.version>2.0.1.Final</validation-api.version>
 
     <copy-rename-maven-plugin.version>1.0</copy-rename-maven-plugin.version>
     <jsonschema2pojo-maven-plugin.version>1.1.2</jsonschema2pojo-maven-plugin.version>
@@ -90,7 +92,13 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.12.0</version>
+      <version>${commons-lang3.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.validation</groupId>
+      <artifactId>validation-api</artifactId>
+      <version>${validation-api.version}</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,6 @@
     <openapi-generator.version>7.3.0</openapi-generator.version>
     <mapstruct.version>1.5.3.Final</mapstruct.version>
     <wiremock.version>3.4.2</wiremock.version>
-    <testcontainers.version>1.19.3</testcontainers.version>
     <embedded.db.version>2.2.0</embedded.db.version>
     <folio-util.version>35.0.3</folio-util.version>
     <commons-lang3.version>3.14.0</commons-lang3.version>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,6 @@
     <wiremock.version>2.27.2</wiremock.version>
     <testcontainers.version>1.17.6</testcontainers.version>
     <embedded.db.version>2.2.0</embedded.db.version>
-    <pubsub.client.version>2.7.0</pubsub.client.version>
     <folio-util.version>35.0.3</folio-util.version>
     <folio-spring-support.version>7.2.0</folio-spring-support.version>
 
@@ -86,6 +85,12 @@
           <artifactId>spring-boot-starter-logging</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.12.0</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -24,14 +24,14 @@
 
   <properties>
     <java.version>17</java.version>
-    <folio-spring-base.version>7.2.2</folio-spring-base.version>
+    <folio-spring-base.version>8.0.0</folio-spring-base.version>
     <openapi-generator.version>6.2.1</openapi-generator.version>
     <mapstruct.version>1.5.3.Final</mapstruct.version>
     <wiremock.version>2.27.2</wiremock.version>
     <testcontainers.version>1.17.6</testcontainers.version>
     <embedded.db.version>2.2.0</embedded.db.version>
     <folio-util.version>35.0.3</folio-util.version>
-    <folio-spring-support.version>7.2.0</folio-spring-support.version>
+    <folio-spring-cql.version>8.0.0</folio-spring-cql.version>
 
     <copy-rename-maven-plugin.version>1.0</copy-rename-maven-plugin.version>
     <jsonschema2pojo-maven-plugin.version>1.1.2</jsonschema2pojo-maven-plugin.version>
@@ -64,7 +64,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-spring-cql</artifactId>
-      <version>${folio-spring-support.version}</version>
+      <version>${folio-spring-cql.version}</version>
     </dependency>
 
     <dependency>

--- a/src/test/java/org/folio/circulation/item/controller/CirculationItemControllerTest.java
+++ b/src/test/java/org/folio/circulation/item/controller/CirculationItemControllerTest.java
@@ -1,6 +1,6 @@
 package org.folio.circulation.item.controller;
 
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.folio.circulation.item.domain.dto.CirculationItem;
 import org.folio.circulation.item.domain.dto.ItemStatus;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/folio/circulation/item/controller/CirculationItemControllerTest.java
+++ b/src/test/java/org/folio/circulation/item/controller/CirculationItemControllerTest.java
@@ -126,7 +126,7 @@ class CirculationItemControllerTest extends BaseIT {
   }
 
   @Test
-  void getCirculationItemByBarcode() throws Exception {
+  void getCirculationItemByBarcodeUsingCqlQuery() throws Exception {
     var id = UUID.randomUUID();
     var barcode = RandomStringUtils.randomAlphabetic(10).toUpperCase();
     var circulationItemRequest = createCirculationItem(id);
@@ -143,7 +143,7 @@ class CirculationItemControllerTest extends BaseIT {
       .andExpect(jsonPath("$.barcode").value(barcode));
 
     mockMvc.perform(
-        get( "/circulation-item?barcode=" + circulationItemRequest.getBarcode())
+        get( "/circulation-item?query=barcode==" + circulationItemRequest.getBarcode())
           .headers(defaultHeaders())
           .contentType(MediaType.APPLICATION_JSON))
       .andExpect(status().isOk());
@@ -153,7 +153,7 @@ class CirculationItemControllerTest extends BaseIT {
     void retrieveCirculationItemNotFoundTest() throws Exception {
         var id = UUID.randomUUID();
         mockMvc.perform(
-                        get(URI_TEMPLATE_CIRCULATION_ITEM + "barcode/" + id)
+                        get(URI_TEMPLATE_CIRCULATION_ITEM  + id)
                                 .headers(defaultHeaders())
                                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNotFound());
@@ -163,10 +163,12 @@ class CirculationItemControllerTest extends BaseIT {
   void getCirculationItemByBarcodeNotFoundTest() throws Exception {
     var barcode = UUID.randomUUID();
     mockMvc.perform(
-        get(URI_TEMPLATE_CIRCULATION_ITEM + "barcode/" + barcode)
+        get("/circulation-item?query=barcode==" + barcode)
           .headers(defaultHeaders())
           .contentType(MediaType.APPLICATION_JSON))
-      .andExpect(status().isNotFound());
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.totalRecords").value(0))
+      .andExpect(jsonPath("$.items").isEmpty());
   }
 
     @Test


### PR DESCRIPTION
## Purpose
The purpose of the PR is to implement MODCITEM-25

## Approach
All the dependencies are upgraded for Q release. When the Openapi version is upgraded to 7.3.0 , it is creating the constructor. So the addition of lombok is failing in some cases. So in order to fix it, added the below annotation by refering to this [link](https://github.com/OpenAPITools/openapi-generator/issues/15494)

`<generatedConstructorWithRequiredArgs>false</generatedConstructorWithRequiredArgs>
`

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
