### PR TITLE
Remove unused dependency json-path

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,11 +98,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.jayway.jsonpath</groupId>
-      <artifactId>json-path</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-xml</artifactId>
     </dependency>


### PR DESCRIPTION
## Purpose
json-path is a runtime dependency in pom.xml but not used.

## Approach
Remove from pom.xml